### PR TITLE
Implement favorite deletion management

### DIFF
--- a/src/app/sections/favs/favs.component.html
+++ b/src/app/sections/favs/favs.component.html
@@ -13,6 +13,7 @@
       <h4 class="text-light mb-0">
         <i class="bi bi-bookmark-check-fill me-2 text-warning"></i>Gestionar favoritos
       </h4>
+      <button class="btn btn-danger btn-sm" (click)="clearFavorites()">Eliminar todos</button>
 
     </div>
 
@@ -102,7 +103,9 @@
                 <i class="bi bi-tag-fill me-1 text-warning"></i>{{ fav.itemType }}
               </span>
 
-              <i class="bi bi-trash-fill me-1"></i>Eliminar
+              <button class="btn btn-link text-danger p-0" (click)="removeFavorite(fav.id, type)">
+                <i class="bi bi-trash-fill me-1"></i>Eliminar
+              </button>
 
             </div>
 


### PR DESCRIPTION
## Summary
- support backend id on favorite responses
- group favorites with id value when loading
- allow deleting individual favorites and clearing all
- wire favorite deletion controls in UI
- clean up leftover comment

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685341e89ce08328845dd0f883aef92d