### PR TITLE
Enable favorite deletion UI

### DIFF
--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -206,7 +206,7 @@ export class DataService {
     const headers = { Authorization: `Bearer ${token}` };
 
     return this.http.delete(
-      'https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/favorites/all',
+      'https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/favorites',
       { headers }
     );
   }

--- a/src/app/sections/favs/favs.component.html
+++ b/src/app/sections/favs/favs.component.html
@@ -24,6 +24,10 @@
     <div *ngIf="successMsg" class="alert alert-success fade-up">{{ successMsg }}</div>
     <div *ngIf="errorMsg" class="alert alert-danger fade-up">{{ errorMsg }}</div>
 
+    <button class="btn btn-danger mb-4" (click)="deleteAllFavorites()">
+      <i class="bi bi-trash-fill me-1"></i>Eliminar todos
+    </button>
+
     <!-- Grupo por tipo -->
     <div *ngFor="let type of objectKeys(groupedFavorites)" class="mb-5 fade-up">
       <h4 class="text-capitalize text-lime mb-4 border-bottom border-lime pb-2">
@@ -102,7 +106,9 @@
                 <i class="bi bi-tag-fill me-1 text-warning"></i>{{ fav.itemType }}
               </span>
 
-              <i class="bi bi-trash-fill me-1"></i>Eliminar
+              <button class="btn btn-sm btn-danger" (click)="removeFavorite(fav.itemId)">
+                <i class="bi bi-trash-fill me-1"></i>Eliminar
+              </button>
 
             </div>
 

--- a/src/app/sections/favs/favs.component.ts
+++ b/src/app/sections/favs/favs.component.ts
@@ -62,8 +62,21 @@ export class FavsComponent implements OnInit {
 }
 
 
+  removeFavorite(id: number) {
+    this.data.removeFavorite(id).subscribe({
+      next: () => { this.successMsg = 'Favorito eliminado'; this.loadFavorites(); },
+      error: () => { this.errorMsg = 'No se pudo eliminar el favorito'; }
+    });
+  }
+
+  deleteAllFavorites() {
+    this.data.deleteAllFavorites().subscribe({
+      next: () => { this.successMsg = 'Favoritos eliminados'; this.loadFavorites(); },
+      error: () => { this.errorMsg = 'No se pudieron eliminar los favoritos'; }
+    });
+  }
 
 
-//nuevo
+
 
 }


### PR DESCRIPTION
## Summary
- point deleteAllFavorites service to correct endpoint
- add methods to remove one or all favorites
- wire up favorite removal buttons in the UI

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ff13baa48328912dc7252f683673