### PR TITLE
Fix favorites deletion with id mapping

### DIFF
--- a/src/app/sections/favs/favs.component.html
+++ b/src/app/sections/favs/favs.component.html
@@ -106,7 +106,7 @@
                 <i class="bi bi-tag-fill me-1 text-warning"></i>{{ fav.itemType }}
               </span>
 
-              <button class="btn btn-sm btn-danger" (click)="removeFavorite(fav.itemId)">
+              <button class="btn btn-sm btn-danger" (click)="removeFavorite(fav.id)">
                 <i class="bi bi-trash-fill me-1"></i>Eliminar
               </button>
 

--- a/src/app/sections/favs/favs.component.ts
+++ b/src/app/sections/favs/favs.component.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 
 interface FavoriteResponse {
+  id: number;            // nuevo campo
   itemType: string;
   itemId: number;
   itemData?: any; // JSON completo desde PandaScore
@@ -34,18 +35,19 @@ export class FavsComponent implements OnInit {
 
   loadFavorites() {
     this.data.getFavorites().subscribe({
-      next: (res: FavoriteResponse[]) => {
-        console.log('Favoritos desde el backend:', res);
+      next: (res: any[]) => {
         this.groupedFavorites = {};
-
-        res.forEach(fav => {
+        res.forEach(f => {
+          const fav: FavoriteResponse = {
+            id: f.id,
+            itemType: f.itemType,
+            itemId: f.itemId,
+            itemData: f.itemData
+          };
           const group = fav.itemType.toLowerCase();
-          if (!this.groupedFavorites[group]) {
-            this.groupedFavorites[group] = [];
-          }
+          if (!this.groupedFavorites[group]) this.groupedFavorites[group] = [];
           this.groupedFavorites[group].push(fav);
         });
-
         this.successMsg = '';
         this.errorMsg = '';
       },


### PR DESCRIPTION
## Summary
- add `id` field for `FavoriteResponse`
- map favorites to include `id` in `loadFavorites`
- update delete button to call `removeFavorite` with the favorite id

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685402feae248328b3fe7d0c611eb270