### PR TITLE
Add favorite functionality for categories

### DIFF
--- a/src/app/sections/categories/categories.component.html
+++ b/src/app/sections/categories/categories.component.html
@@ -47,6 +47,12 @@
                 <span class="badge bg-secondary text-uppercase small">
                   {{ formatSlug(league.slug) }}
                 </span>
+                <button
+                  class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('league', league.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -78,13 +84,19 @@
                 </p>
 
                 <!-- Fechas -->
-                <p class="small text-muted mb-0">
-                  <i class="bi bi-calendar-event me-2 text-warning"></i>
-                  {{ serie.begin_at | date:'MMM d, y' }} - {{ serie.end_at | date:'MMM d, y' }}
-                </p>
+                  <p class="small text-muted mb-0">
+                    <i class="bi bi-calendar-event me-2 text-warning"></i>
+                    {{ serie.begin_at | date:'MMM d, y' }} - {{ serie.end_at | date:'MMM d, y' }}
+                  </p>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('serie', serie.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -117,17 +129,23 @@
                 </ul>
 
                 <!-- Equipos -->
-                <div *ngIf="tournament.teams?.length" class="d-flex flex-wrap gap-2 mt-auto">
-                  <div *ngFor="let team of tournament.teams"
-                    class="team-pill d-flex align-items-center gap-2 px-2 py-1 rounded">
-                    <img [src]="team.image_url" [alt]="team.name" width="24" height="24"
-                      class="rounded-circle bg-dark border">
-                    <span class="small text-light">{{ team.acronym }}</span>
+                  <div *ngIf="tournament.teams?.length" class="d-flex flex-wrap gap-2 mt-auto">
+                    <div *ngFor="let team of tournament.teams"
+                      class="team-pill d-flex align-items-center gap-2 px-2 py-1 rounded">
+                      <img [src]="team.image_url" [alt]="team.name" width="24" height="24"
+                        class="rounded-circle bg-dark border">
+                      <span class="small text-light">{{ team.acronym }}</span>
+                    </div>
                   </div>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('tournament', tournament.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
                 </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -169,6 +187,12 @@
                     Status: {{ match.status | titlecase }}
                   </li>
                 </ul>
+                <button
+                  class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('match', match.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -210,12 +234,18 @@
                   <i class="bi bi-globe2 me-1 text-primary"></i>
                   {{ league.region || 'Global' }}
                 </p>
-                <span class="badge bg-secondary text-uppercase small">
-                  {{ formatSlug(league.slug) }}
-                </span>
+                  <span class="badge bg-secondary text-uppercase small">
+                    {{ formatSlug(league.slug) }}
+                  </span>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('league', league.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -234,12 +264,18 @@
                   <i class="bi bi-calendar me-2 text-warning"></i>
                   {{ serie.begin_at | date:'MMM d, y' }} - {{ serie.end_at | date:'MMM d, y' }}
                 </p>
-                <span class="badge badge-custom mt-auto align-self-start">
-                  {{ serie.season ? (serie.season + ' ' + serie.year) : serie.year }}
-                </span>
+                  <span class="badge badge-custom mt-auto align-self-start">
+                    {{ serie.season ? (serie.season + ' ' + serie.year) : serie.year }}
+                  </span>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('serie', serie.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -272,17 +308,23 @@
                 </ul>
 
                 <!-- Equipos -->
-                <div *ngIf="tournament.teams?.length" class="d-flex flex-wrap gap-2 mt-auto">
-                  <div *ngFor="let team of tournament.teams"
-                    class="team-pill d-flex align-items-center gap-2 px-2 py-1 rounded">
-                    <img [src]="team.image_url" [alt]="team.name" width="24" height="24"
-                      class="rounded-circle bg-dark border">
-                    <span class="small text-light">{{ team.acronym }}</span>
+                  <div *ngIf="tournament.teams?.length" class="d-flex flex-wrap gap-2 mt-auto">
+                    <div *ngFor="let team of tournament.teams"
+                      class="team-pill d-flex align-items-center gap-2 px-2 py-1 rounded">
+                      <img [src]="team.image_url" [alt]="team.name" width="24" height="24"
+                        class="rounded-circle bg-dark border">
+                      <span class="small text-light">{{ team.acronym }}</span>
+                    </div>
                   </div>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('csgo_tournament', tournament.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
                 </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -324,6 +366,12 @@
                     Status: {{ match.status | titlecase }}
                   </li>
                 </ul>
+                <button
+                  class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('csgo_match', match.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -367,12 +415,18 @@
                   <i class="bi bi-globe2 me-1 text-primary"></i>
                   {{ league.region || 'Global' }}
                 </p>
-                <span class="badge bg-secondary text-uppercase small">
-                  {{ formatSlug(league.slug) }}
-                </span>
+                  <span class="badge bg-secondary text-uppercase small">
+                    {{ formatSlug(league.slug) }}
+                  </span>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('league', league.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -391,12 +445,18 @@
                   <i class="bi bi-calendar me-2 text-warning"></i>
                   {{ serie.begin_at | date:'MMM d, y' }} - {{ serie.end_at | date:'MMM d, y' }}
                 </p>
-                <span class="badge badge-custom mt-auto align-self-start">
-                  {{ serie.season ? (serie.season + ' ' + serie.year) : serie.year }}
-                </span>
+                  <span class="badge badge-custom mt-auto align-self-start">
+                    {{ serie.season ? (serie.season + ' ' + serie.year) : serie.year }}
+                  </span>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('serie', serie.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -436,10 +496,16 @@
                       class="rounded-circle bg-dark border">
                     <span class="small text-light">{{ team.acronym }}</span>
                   </div>
+                  </div>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('tournament', tournament.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
                 </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -472,18 +538,24 @@
                     <i class="bi bi-controller me-2 text-success"></i>
                     Format: Bo{{ match.number_of_games }}
                   </li>
-                  <li>
-                    <i class="bi bi-circle me-2" [ngClass]="{
-                    'text-success': match.status === 'finished',
-                    'text-warning': match.status === 'running',
-                    'text-muted': match.status === 'not_started'
-                  }"></i>
-                    Status: {{ match.status | titlecase }}
-                  </li>
-                </ul>
+                    <li>
+                      <i class="bi bi-circle me-2" [ngClass]="{
+                      'text-success': match.status === 'finished',
+                      'text-warning': match.status === 'running',
+                      'text-muted': match.status === 'not_started'
+                    }"></i>
+                      Status: {{ match.status | titlecase }}
+                    </li>
+                  </ul>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('match', match.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -525,6 +597,12 @@
                 <span class="badge bg-secondary text-uppercase small">
                   {{ formatSlug(league.slug) }}
                 </span>
+                <button
+                  class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('league', league.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -556,13 +634,19 @@
                 </p>
 
                 <!-- Fechas -->
-                <p class="small text-muted mb-0">
-                  <i class="bi bi-calendar-event me-2 text-warning"></i>
-                  {{ serie.begin_at | date:'MMM d, y' }} - {{ serie.end_at | date:'MMM d, y' }}
-                </p>
+                  <p class="small text-muted mb-0">
+                    <i class="bi bi-calendar-event me-2 text-warning"></i>
+                    {{ serie.begin_at | date:'MMM d, y' }} - {{ serie.end_at | date:'MMM d, y' }}
+                  </p>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('serie', serie.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -595,17 +679,23 @@
                 </ul>
 
                 <!-- Equipos -->
-                <div *ngIf="tournament.teams?.length" class="d-flex flex-wrap gap-2 mt-auto">
-                  <div *ngFor="let team of tournament.teams"
-                    class="team-pill d-flex align-items-center gap-2 px-2 py-1 rounded">
-                    <img [src]="team.image_url" [alt]="team.name" width="24" height="24"
-                      class="rounded-circle bg-dark border">
-                    <span class="small text-light">{{ team.acronym }}</span>
+                  <div *ngIf="tournament.teams?.length" class="d-flex flex-wrap gap-2 mt-auto">
+                    <div *ngFor="let team of tournament.teams"
+                      class="team-pill d-flex align-items-center gap-2 px-2 py-1 rounded">
+                      <img [src]="team.image_url" [alt]="team.name" width="24" height="24"
+                        class="rounded-circle bg-dark border">
+                      <span class="small text-light">{{ team.acronym }}</span>
+                    </div>
                   </div>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('tournament', tournament.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
                 </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }
@@ -638,18 +728,24 @@
                     <i class="bi bi-controller me-2 text-success"></i>
                     Format: Bo{{ match.number_of_games }}
                   </li>
-                  <li>
-                    <i class="bi bi-circle me-2" [ngClass]="{
-                          'text-success': match.status === 'finished',
-                          'text-warning': match.status === 'running',
-                          'text-muted': match.status === 'not_started'
-                        }"></i>
-                    Status: {{ match.status | titlecase }}
-                  </li>
-                </ul>
+                    <li>
+                      <i class="bi bi-circle me-2" [ngClass]="{
+                            'text-success': match.status === 'finished',
+                            'text-warning': match.status === 'running',
+                            'text-muted': match.status === 'not_started'
+                          }"></i>
+                      Status: {{ match.status | titlecase }}
+                    </li>
+                  </ul>
+                  <button
+                    class="btn btn-sm btn-warning mt-2 w-100 d-flex align-items-center justify-content-center gap-2"
+                    (click)="addToFavorites('match', match.id)">
+                    <i class="bi bi-star-fill"></i>
+                    Save Favorite
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
           }
         </div>
         }

--- a/src/app/sections/categories/categories.component.ts
+++ b/src/app/sections/categories/categories.component.ts
@@ -1,6 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { DataService } from './../../data.service';
 import { CommonModule } from '@angular/common';
+import { AuthService } from '../../auth.service';
+
+interface FavoriteResponse {
+  id?: number;
+  itemType: string;
+  itemId: number;
+  itemData?: any;
+}
 
 @Component({
   selector: 'app-categories',
@@ -8,8 +16,8 @@ import { CommonModule } from '@angular/common';
   templateUrl: './categories.component.html',
   styleUrl: './categories.component.css',
 })
-export class CategoriesComponent {
-  constructor(private data: DataService) {
+export class CategoriesComponent implements OnInit {
+  constructor(private data: DataService, private authService: AuthService) {
     this.getLolLeagues();
     this.getLolSeries();
     this.getLolTournaments();
@@ -26,6 +34,11 @@ export class CategoriesComponent {
     this.getValorantSeries();
     this.getValorantTournaments();
     this.getValorantMatches();
+  }
+
+  ngOnInit(): void {
+    this.authService.refreshUser();
+    this.loadFavorites();
   }
 
   currentViewLoL: string = '';
@@ -51,7 +64,11 @@ export class CategoriesComponent {
   valorantLeagues: any[] = [];
   valorantSeries: any[] = [];
   valorantTournaments: any[] = [];
-  valorantMatches: any[] = [];    
+  valorantMatches: any[] = [];
+
+  favorites: FavoriteResponse[] = [];
+  successMsg: string = '';
+  errorMsg: string = '';
 
   // LoL
 
@@ -186,6 +203,50 @@ export class CategoriesComponent {
       this.valorantMatches = res;
 
       console.log(this.valorantMatches);
+    });
+  }
+
+  loadFavorites() {
+    this.data.getFavorites().subscribe({
+      next: (res) => {
+        this.favorites = res.map((f: any) => ({
+          id: f.id,
+          itemType: f.itemType,
+          itemId: f.itemId,
+          itemData: f.itemData,
+        }));
+      },
+      error: (err) => {
+        console.error('Error cargando favoritos', err);
+      },
+    });
+  }
+
+  addToFavorites(type: string, referenceId: number) {
+    const alreadyExists = this.favorites.some(
+      (fav) => fav.itemId === referenceId && fav.itemType === type
+    );
+
+    if (alreadyExists) {
+      this.errorMsg = 'Este ítem ya está en favoritos.';
+      return;
+    }
+
+    const payload = { referenceId, type };
+    this.data.addFavorite(payload).subscribe({
+      next: (res) => {
+        this.successMsg = 'Añadido correctamente.';
+        this.favorites.push({
+          id: res.id,
+          itemId: referenceId,
+          itemType: type,
+          itemData: res.itemData || {},
+        });
+      },
+      error: (err) => {
+        this.errorMsg = 'Error al añadir a favoritos.';
+        console.error(err);
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- add FavoriteResponse interface and favorites management in categories
- allow categories component to load and add favorites
- show Add Favorite buttons for all League, Series, Tournament and Match cards

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685476856eb08328ba82b2e07ffef446