### PR TITLE
Add privacy and terms pages

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,6 +7,8 @@ import { DiscoverComponent } from './sections/discover/discover.component';
 import { FavsComponent } from './sections/favs/favs.component';
 import { AboutUSComponent } from './sections/about-us/about-us.component';
 import { AccountComponent } from './sections/account/account.component';
+import { PrivacyComponent } from './sections/privacy/privacy.component';
+import { TermsComponent } from './sections/terms/terms.component';
 import { AuthGuard } from './guards/auth.guard';
 
 export const routes: Routes = [
@@ -23,5 +25,7 @@ export const routes: Routes = [
   { path: "register", component: RegisterComponent },
   { path: "aboutus", component: AboutUSComponent },
   { path: 'account', component: AccountComponent },
+  { path: 'privacy', component: PrivacyComponent },
+  { path: 'terms', component: TermsComponent },
   { path: "**", component: HomeComponent }
 ];

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -11,8 +11,8 @@
 
     <!-- Menú de enlaces -->
     <ul class="footer-links list-unstyled d-flex gap-4 mb-0">
-      <li><a href="#" class="footer-link">Privacy</a></li>
-      <li><a href="#" class="footer-link">Terms</a></li>
+      <li><a routerLink="/privacy" class="footer-link">Privacy</a></li>
+      <li><a routerLink="/terms" class="footer-link">Terms</a></li>
       <li><a href="#" class="footer-link">Contact</a></li>
       <li><a href="#" class="footer-link">Help</a></li>
     </ul>

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-footer',
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './footer.component.html',
   styleUrl: './footer.component.css'
 })

--- a/src/app/sections/privacy/privacy.component.css
+++ b/src/app/sections/privacy/privacy.component.css
@@ -1,0 +1,1 @@
+/* Privacy component styles */

--- a/src/app/sections/privacy/privacy.component.html
+++ b/src/app/sections/privacy/privacy.component.html
@@ -1,0 +1,2 @@
+<h1>Privacy Policy</h1>
+<p>This page describes how we handle your personal data.</p>

--- a/src/app/sections/privacy/privacy.component.spec.ts
+++ b/src/app/sections/privacy/privacy.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PrivacyComponent } from './privacy.component';
+
+describe('PrivacyComponent', () => {
+  let component: PrivacyComponent;
+  let fixture: ComponentFixture<PrivacyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PrivacyComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrivacyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/sections/privacy/privacy.component.ts
+++ b/src/app/sections/privacy/privacy.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-privacy',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './privacy.component.html',
+  styleUrls: ['./privacy.component.css']
+})
+export class PrivacyComponent {}

--- a/src/app/sections/terms/terms.component.css
+++ b/src/app/sections/terms/terms.component.css
@@ -1,0 +1,1 @@
+/* Terms component styles */

--- a/src/app/sections/terms/terms.component.html
+++ b/src/app/sections/terms/terms.component.html
@@ -1,0 +1,2 @@
+<h1>Terms of Service</h1>
+<p>This page outlines the rules and conditions for using this site.</p>

--- a/src/app/sections/terms/terms.component.spec.ts
+++ b/src/app/sections/terms/terms.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TermsComponent } from './terms.component';
+
+describe('TermsComponent', () => {
+  let component: TermsComponent;
+  let fixture: ComponentFixture<TermsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TermsComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TermsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/sections/terms/terms.component.ts
+++ b/src/app/sections/terms/terms.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-terms',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './terms.component.html',
+  styleUrls: ['./terms.component.css']
+})
+export class TermsComponent {}


### PR DESCRIPTION
## Summary
- create Privacy and Terms standalone components
- route to them from the router
- link new pages in the footer
- provide unit tests for the new components

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685537fb7c1883289df15432a713e32d