### PR TITLE
Enable favorites in categories

### DIFF
--- a/src/app/sections/categories/categories.component.html
+++ b/src/app/sections/categories/categories.component.html
@@ -47,6 +47,12 @@
                 <span class="badge bg-secondary text-uppercase small">
                   {{ formatSlug(league.slug) }}
                 </span>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('league', league.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -82,6 +88,12 @@
                   <i class="bi bi-calendar-event me-2 text-warning"></i>
                   {{ serie.begin_at | date:'MMM d, y' }} - {{ serie.end_at | date:'MMM d, y' }}
                 </p>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('series', serie.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -125,6 +137,12 @@
                     <span class="small text-light">{{ team.acronym }}</span>
                   </div>
                 </div>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('tournament', tournament.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -160,18 +178,24 @@
                     <i class="bi bi-controller me-2 text-success"></i>
                     Format: Bo{{ match.number_of_games }}
                   </li>
-                  <li>
-                    <i class="bi bi-circle me-2" [ngClass]="{
-                          'text-success': match.status === 'finished',
-                          'text-warning': match.status === 'running',
-                          'text-muted': match.status === 'not_started'
-                        }"></i>
-                    Status: {{ match.status | titlecase }}
-                  </li>
-                </ul>
-              </div>
+                <li>
+                  <i class="bi bi-circle me-2" [ngClass]="{
+                        'text-success': match.status === 'finished',
+                        'text-warning': match.status === 'running',
+                        'text-muted': match.status === 'not_started'
+                      }"></i>
+                  Status: {{ match.status | titlecase }}
+                </li>
+              </ul>
+              <button
+                class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                (click)="addToFavorites('match', match.id)">
+                <i class="bi bi-star-fill"></i>
+                Save Favorite
+              </button>
             </div>
           </div>
+        </div>
           }
         </div>
         }
@@ -213,6 +237,12 @@
                 <span class="badge bg-secondary text-uppercase small">
                   {{ formatSlug(league.slug) }}
                 </span>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('league', league.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -237,6 +267,12 @@
                 <span class="badge badge-custom mt-auto align-self-start">
                   {{ serie.season ? (serie.season + ' ' + serie.year) : serie.year }}
                 </span>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('series', serie.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -280,6 +316,12 @@
                     <span class="small text-light">{{ team.acronym }}</span>
                   </div>
                 </div>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('tournament', tournament.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -315,18 +357,24 @@
                     <i class="bi bi-controller me-2 text-success"></i>
                     Format: Bo{{ match.number_of_games }}
                   </li>
-                  <li>
-                    <i class="bi bi-circle me-2" [ngClass]="{
-                          'text-success': match.status === 'finished',
-                          'text-warning': match.status === 'running',
-                          'text-muted': match.status === 'not_started'
-                        }"></i>
-                    Status: {{ match.status | titlecase }}
-                  </li>
-                </ul>
-              </div>
+                <li>
+                  <i class="bi bi-circle me-2" [ngClass]="{
+                        'text-success': match.status === 'finished',
+                        'text-warning': match.status === 'running',
+                        'text-muted': match.status === 'not_started'
+                      }"></i>
+                  Status: {{ match.status | titlecase }}
+                </li>
+              </ul>
+              <button
+                class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                (click)="addToFavorites('match', match.id)">
+                <i class="bi bi-star-fill"></i>
+                Save Favorite
+              </button>
             </div>
           </div>
+        </div>
           }
         </div>
         }
@@ -370,6 +418,12 @@
                 <span class="badge bg-secondary text-uppercase small">
                   {{ formatSlug(league.slug) }}
                 </span>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('league', league.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -394,6 +448,12 @@
                 <span class="badge badge-custom mt-auto align-self-start">
                   {{ serie.season ? (serie.season + ' ' + serie.year) : serie.year }}
                 </span>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('series', serie.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -437,6 +497,12 @@
                     <span class="small text-light">{{ team.acronym }}</span>
                   </div>
                 </div>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('tournament', tournament.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -472,18 +538,24 @@
                     <i class="bi bi-controller me-2 text-success"></i>
                     Format: Bo{{ match.number_of_games }}
                   </li>
-                  <li>
-                    <i class="bi bi-circle me-2" [ngClass]="{
-                    'text-success': match.status === 'finished',
-                    'text-warning': match.status === 'running',
-                    'text-muted': match.status === 'not_started'
-                  }"></i>
-                    Status: {{ match.status | titlecase }}
-                  </li>
-                </ul>
-              </div>
+                <li>
+                  <i class="bi bi-circle me-2" [ngClass]="{
+                      'text-success': match.status === 'finished',
+                      'text-warning': match.status === 'running',
+                      'text-muted': match.status === 'not_started'
+                    }"></i>
+                  Status: {{ match.status | titlecase }}
+                </li>
+              </ul>
+              <button
+                class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                (click)="addToFavorites('match', match.id)">
+                <i class="bi bi-star-fill"></i>
+                Save Favorite
+              </button>
             </div>
           </div>
+        </div>
           }
         </div>
         }
@@ -525,6 +597,12 @@
                 <span class="badge bg-secondary text-uppercase small">
                   {{ formatSlug(league.slug) }}
                 </span>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('league', league.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -560,6 +638,12 @@
                   <i class="bi bi-calendar-event me-2 text-warning"></i>
                   {{ serie.begin_at | date:'MMM d, y' }} - {{ serie.end_at | date:'MMM d, y' }}
                 </p>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('series', serie.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -603,6 +687,12 @@
                     <span class="small text-light">{{ team.acronym }}</span>
                   </div>
                 </div>
+                <button
+                  class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                  (click)="addToFavorites('tournament', tournament.id)">
+                  <i class="bi bi-star-fill"></i>
+                  Save Favorite
+                </button>
               </div>
             </div>
           </div>
@@ -638,18 +728,24 @@
                     <i class="bi bi-controller me-2 text-success"></i>
                     Format: Bo{{ match.number_of_games }}
                   </li>
-                  <li>
-                    <i class="bi bi-circle me-2" [ngClass]="{
+                <li>
+                  <i class="bi bi-circle me-2" [ngClass]="{
                           'text-success': match.status === 'finished',
                           'text-warning': match.status === 'running',
                           'text-muted': match.status === 'not_started'
                         }"></i>
-                    Status: {{ match.status | titlecase }}
-                  </li>
-                </ul>
-              </div>
+                  Status: {{ match.status | titlecase }}
+                </li>
+              </ul>
+              <button
+                class="btn btn-sm btn-warning mt-3 w-100 d-flex align-items-center justify-content-center gap-2"
+                (click)="addToFavorites('match', match.id)">
+                <i class="bi bi-star-fill"></i>
+                Save Favorite
+              </button>
             </div>
           </div>
+        </div>
           }
         </div>
         }


### PR DESCRIPTION
## Summary
- let users add leagues, series, tournaments and matches to favorites in the Categories section
- sync favorites on init by injecting `AuthService`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c8462a588328909c00dbeed7b445