### PR TITLE
Add pagination support in frontend

### DIFF
--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -1,65 +1,71 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 @Injectable({
   providedIn: 'root'
 })
 export class DataService {
+  private readonly baseUrl = 'https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api';
 
   constructor(private http: HttpClient) { }
 
+  private getPaginated<T>(path: string, page: number = 1, limit: number = 10): Observable<T> {
+    const params = new HttpParams().set('page', page).set('limit', limit);
+    return this.http.get<T>(`${this.baseUrl}/${path}`, { params });
+  }
+
   // General methods
 
-  getLeagues() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/leagues')
+  getLeagues(page: number = 1, limit: number = 10) {
+    return this.getPaginated('leagues', page, limit);
   }
 
-  getTeams() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/teams')
+  getTeams(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/teams', page, limit);
   }
 
-  getPlayers() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/players')
+  getPlayers(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/players', page, limit);
   }
 
-  getmatches() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/matches')
+  getmatches(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/matches', page, limit);
   }
 
   // Game-specific methods
 
   // League of Legends
 
-  getLolLeagues() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/lol/leagues')
+  getLolLeagues(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/lol/leagues', page, limit)
   }
 
-  getLolSeries() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/lol/series')
+  getLolSeries(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/lol/series', page, limit)
   }
 
-  getLolTournaments() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/lol/tournaments')
+  getLolTournaments(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/lol/tournaments', page, limit)
   }
 
-  getLolMatches() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/lol/matches')
+  getLolMatches(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/lol/matches', page, limit)
 }
 
-  getLolChampions() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/lol/champions')
+  getLolChampions(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/lol/champions', page, limit)
 
   }
-  getLolItemns() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/lol/items')
+  getLolItemns(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/lol/items', page, limit)
 
   }
-  getLolrunes() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/lol/runes-reforged')
+  getLolrunes(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/lol/runes-reforged', page, limit)
 
   }
-  getLolspells() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/lol/spells')
+  getLolspells(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/lol/spells', page, limit)
 
   }
 
@@ -68,88 +74,88 @@ export class DataService {
 
   // Counter-Strike: Global Offensive
 
-  getCSGOLeagues() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/csgo/leagues')
+  getCSGOLeagues(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/csgo/leagues', page, limit)
   }
 
-  getCSGOSeries() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/csgo/series')
+  getCSGOSeries(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/csgo/series', page, limit)
   }
 
-  getCSGOTournaments() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/csgo/tournaments')
+  getCSGOTournaments(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/csgo/tournaments', page, limit)
   }
 
-  getCSGOMatches() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/csgo/matches')
+  getCSGOMatches(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/csgo/matches', page, limit)
   }
 
-  getCSGOmaps() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/csgo/maps')
+  getCSGOmaps(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/csgo/maps', page, limit)
 
   }
-  getCSGOweapons() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/csgo/weapons')
+  getCSGOweapons(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/csgo/weapons', page, limit)
   }
 
   // Dota 2
 
-  getDota2Leagues() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/dota2/leagues')
+  getDota2Leagues(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/dota2/leagues', page, limit)
   }
 
-  getDota2Series() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/dota2/series')
+  getDota2Series(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/dota2/series', page, limit)
   }
 
-  getDota2Tournaments() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/dota2/tournaments')
+  getDota2Tournaments(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/dota2/tournaments', page, limit)
   }
 
-  getDota2Matches() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/dota2/matches')
+  getDota2Matches(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/dota2/matches', page, limit)
   }
 
-  getDota2Abilities() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/dota2/abilities')
+  getDota2Abilities(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/dota2/abilities', page, limit)
   }
-  getDota2heroes() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/dota2/heroes')
+  getDota2heroes(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/dota2/heroes', page, limit)
   }
-  getDota2items() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/dota2/items')
+  getDota2items(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/dota2/items', page, limit)
   }
 
 
 
   // Valorant
 
-  getValorantLeagues() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/valorant/leagues')
+  getValorantLeagues(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/valorant/leagues', page, limit)
   }
 
-  getValorantSeries() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/valorant/series')
+  getValorantSeries(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/valorant/series', page, limit)
   }
 
-  getValorantTournaments() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/valorant/tournaments')
+  getValorantTournaments(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/valorant/tournaments', page, limit)
   }
 
-  getValorantMatches() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/valorant/matches')
+  getValorantMatches(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/valorant/matches', page, limit)
   }
-  getValoranabilities() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/valorant/abilities')
+  getValoranabilities(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/valorant/abilities', page, limit)
   }
-  getValorantmaps() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/valorant/maps')
+  getValorantmaps(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/valorant/maps', page, limit)
   }
-  getValorantweapons() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/valorant/weapons')
+  getValorantweapons(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/valorant/weapons', page, limit)
   }
-  getValorantagents() {
-    return this.http.get('https://rjk-backend-hwb4bjfhexaybagg.spaincentral-01.azurewebsites.net/api/pandascore/valorant/agents')
+  getValorantagents(page: number = 1, limit: number = 10) {
+    return this.getPaginated('pandascore/valorant/agents', page, limit)
   }
 
 

--- a/src/app/pipes/paginate.pipe.ts
+++ b/src/app/pipes/paginate.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'paginate',
+  standalone: true
+})
+export class PaginatePipe implements PipeTransform {
+  transform<T>(array: T[], page: number = 1, limit: number = 10): T[] {
+    if (!Array.isArray(array)) return array;
+    const start = (page - 1) * limit;
+    return array.slice(start, start + limit);
+  }
+}

--- a/src/app/sections/categories/categories.component.html
+++ b/src/app/sections/categories/categories.component.html
@@ -52,6 +52,10 @@
           </div>
           }
         </div>
+        <div class="d-flex justify-content-between mt-3">
+          <button class="btn btn-secondary btn-sm" (click)="changePage('lolLeagues', -1)" [disabled]="pages.lolLeagues === 1">Anterior</button>
+          <button class="btn btn-secondary btn-sm" (click)="changePage('lolLeagues', 1)">Siguiente</button>
+        </div>
         }
 
         @if (currentViewLoL === 'series') {
@@ -86,6 +90,10 @@
             </div>
           </div>
           }
+        </div>
+        <div class="d-flex justify-content-between mt-3">
+          <button class="btn btn-secondary btn-sm" (click)="changePage('lolSeries', -1)" [disabled]="pages.lolSeries === 1">Anterior</button>
+          <button class="btn btn-secondary btn-sm" (click)="changePage('lolSeries', 1)">Siguiente</button>
         </div>
         }
 
@@ -129,6 +137,10 @@
             </div>
           </div>
           }
+        </div>
+        <div class="d-flex justify-content-between mt-3">
+          <button class="btn btn-secondary btn-sm" (click)="changePage('lolTournaments', -1)" [disabled]="pages.lolTournaments === 1">Anterior</button>
+          <button class="btn btn-secondary btn-sm" (click)="changePage('lolTournaments', 1)">Siguiente</button>
         </div>
         }
 
@@ -174,6 +186,10 @@
           </div>
           }
         </div>
+        <div class="d-flex justify-content-between mt-3">
+          <button class="btn btn-secondary btn-sm" (click)="changePage('lolMatches', -1)" [disabled]="pages.lolMatches === 1">Anterior</button>
+          <button class="btn btn-secondary btn-sm" (click)="changePage('lolMatches', 1)">Siguiente</button>
+        </div>
         }
       </div>
 
@@ -218,6 +234,10 @@
           </div>
           }
         </div>
+        <div class="d-flex justify-content-between mt-3">
+          <button class="btn btn-secondary btn-sm" (click)="changePage('CSGOLeagues', -1)" [disabled]="pages.CSGOLeagues === 1">Anterior</button>
+          <button class="btn btn-secondary btn-sm" (click)="changePage('CSGOLeagues', 1)">Siguiente</button>
+        </div>
         }
 
         @if (currentViewCSGO === 'series') {
@@ -241,6 +261,10 @@
             </div>
           </div>
           }
+        </div>
+        <div class="d-flex justify-content-between mt-3">
+          <button class="btn btn-secondary btn-sm" (click)="changePage('CSGOSeries', -1)" [disabled]="pages.CSGOSeries === 1">Anterior</button>
+          <button class="btn btn-secondary btn-sm" (click)="changePage('CSGOSeries', 1)">Siguiente</button>
         </div>
         }
 

--- a/src/app/sections/categories/categories.component.ts
+++ b/src/app/sections/categories/categories.component.ts
@@ -33,6 +33,26 @@ export class CategoriesComponent {
   currentViewDota2: string = '';
   currentViewValorant: string = '';
 
+  pageSize = 10;
+  pages: { [key: string]: number } = {
+    lolLeagues: 1,
+    lolSeries: 1,
+    lolTournaments: 1,
+    lolMatches: 1,
+    CSGOLeagues: 1,
+    CSGOSeries: 1,
+    CSGOTournaments: 1,
+    CSGOMatches: 1,
+    dota2Leagues: 1,
+    dota2Series: 1,
+    dota2Tournaments: 1,
+    dota2Matches: 1,
+    valorantLeagues: 1,
+    valorantSeries: 1,
+    valorantTournaments: 1,
+    valorantMatches: 1,
+  };
+
   lolLeagues: any[] = [];
   lolMatches: any[] = [];
   lolSeries: any[] = [];
@@ -51,12 +71,68 @@ export class CategoriesComponent {
   valorantLeagues: any[] = [];
   valorantSeries: any[] = [];
   valorantTournaments: any[] = [];
-  valorantMatches: any[] = [];    
+  valorantMatches: any[] = [];
+
+  changePage(key: string, delta: number) {
+    const next = (this.pages[key] || 1) + delta;
+    if (next < 1) return;
+    this.pages[key] = next;
+    switch (key) {
+      case 'lolLeagues':
+        this.getLolLeagues();
+        break;
+      case 'lolSeries':
+        this.getLolSeries();
+        break;
+      case 'lolTournaments':
+        this.getLolTournaments();
+        break;
+      case 'lolMatches':
+        this.getLolMatches();
+        break;
+      case 'CSGOLeagues':
+        this.getCSGOLeagues();
+        break;
+      case 'CSGOSeries':
+        this.getCSGOSeries();
+        break;
+      case 'CSGOTournaments':
+        this.getCSGOTournaments();
+        break;
+      case 'CSGOMatches':
+        this.getCSGOMatches();
+        break;
+      case 'dota2Leagues':
+        this.getDota2Leagues();
+        break;
+      case 'dota2Series':
+        this.getDota2Series();
+        break;
+      case 'dota2Tournaments':
+        this.getDota2Tournaments();
+        break;
+      case 'dota2Matches':
+        this.getDota2Matches();
+        break;
+      case 'valorantLeagues':
+        this.getValorantLeagues();
+        break;
+      case 'valorantSeries':
+        this.getValorantSeries();
+        break;
+      case 'valorantTournaments':
+        this.getValorantTournaments();
+        break;
+      case 'valorantMatches':
+        this.getValorantMatches();
+        break;
+    }
+  }
 
   // LoL
 
   getLolLeagues() {
-    this.data.getLolLeagues().subscribe((res: any) => {
+    this.data.getLolLeagues(this.pages.lolLeagues, this.pageSize).subscribe((res: any) => {
       this.lolLeagues = res;
 
       console.log(this.lolLeagues);
@@ -64,7 +140,7 @@ export class CategoriesComponent {
   }
 
   getLolSeries() {
-    this.data.getLolSeries().subscribe((res: any) => {
+    this.data.getLolSeries(this.pages.lolSeries, this.pageSize).subscribe((res: any) => {
       this.lolSeries = res;
 
       console.log(this.lolSeries);
@@ -72,7 +148,7 @@ export class CategoriesComponent {
   }
 
   getLolTournaments() {
-    this.data.getLolTournaments().subscribe((res: any) => {
+    this.data.getLolTournaments(this.pages.lolTournaments, this.pageSize).subscribe((res: any) => {
       this.lolTournaments = res;
 
       console.log(this.lolTournaments);
@@ -80,7 +156,7 @@ export class CategoriesComponent {
   }
 
   getLolMatches() {
-    this.data.getLolMatches().subscribe((res: any) => {
+    this.data.getLolMatches(this.pages.lolMatches, this.pageSize).subscribe((res: any) => {
       this.lolMatches = res;
 
       console.log(this.lolMatches);
@@ -90,7 +166,7 @@ export class CategoriesComponent {
   // CSGO
 
   getCSGOLeagues() {
-    this.data.getCSGOLeagues().subscribe((res: any) => {
+    this.data.getCSGOLeagues(this.pages.CSGOLeagues, this.pageSize).subscribe((res: any) => {
       this.CSGOLeagues = res;
 
       console.log(this.CSGOLeagues);
@@ -98,7 +174,7 @@ export class CategoriesComponent {
   }
 
   getCSGOSeries() {
-    this.data.getCSGOSeries().subscribe((res: any) => {
+    this.data.getCSGOSeries(this.pages.CSGOSeries, this.pageSize).subscribe((res: any) => {
       this.CSGOSeries = res;
 
       console.log(this.CSGOSeries);
@@ -106,7 +182,7 @@ export class CategoriesComponent {
   }
 
   getCSGOTournaments() {
-    this.data.getCSGOTournaments().subscribe((res: any) => {
+    this.data.getCSGOTournaments(this.pages.CSGOTournaments, this.pageSize).subscribe((res: any) => {
       this.CSGOTournaments = res;
 
       console.log(this.CSGOTournaments);
@@ -114,7 +190,7 @@ export class CategoriesComponent {
   }
 
   getCSGOMatches() {
-    this.data.getCSGOMatches().subscribe((res: any) => {
+    this.data.getCSGOMatches(this.pages.CSGOMatches, this.pageSize).subscribe((res: any) => {
       this.CSGOMatches = res;
 
       console.log(this.CSGOMatches);
@@ -124,7 +200,7 @@ export class CategoriesComponent {
   // Dota 2
 
   getDota2Leagues() {
-    this.data.getDota2Leagues().subscribe((res: any) => {
+    this.data.getDota2Leagues(this.pages.dota2Leagues, this.pageSize).subscribe((res: any) => {
       this.dota2Leagues = res;
 
       console.log(this.dota2Leagues);
@@ -132,7 +208,7 @@ export class CategoriesComponent {
   }
 
   getDota2Series() {
-    this.data.getDota2Series().subscribe((res: any) => {
+    this.data.getDota2Series(this.pages.dota2Series, this.pageSize).subscribe((res: any) => {
       this.dota2Series = res;
 
       console.log(this.dota2Series);
@@ -140,7 +216,7 @@ export class CategoriesComponent {
   }
 
   getDota2Tournaments() {
-    this.data.getDota2Tournaments().subscribe((res: any) => {
+    this.data.getDota2Tournaments(this.pages.dota2Tournaments, this.pageSize).subscribe((res: any) => {
       this.dota2Tournaments = res;
 
       console.log(this.dota2Tournaments);
@@ -148,7 +224,7 @@ export class CategoriesComponent {
   }
 
   getDota2Matches() {
-    this.data.getDota2Matches().subscribe((res: any) => {
+    this.data.getDota2Matches(this.pages.dota2Matches, this.pageSize).subscribe((res: any) => {
       this.dota2Matches = res;
 
       console.log(this.dota2Matches);
@@ -158,7 +234,7 @@ export class CategoriesComponent {
   // Valorant
 
   getValorantLeagues() {
-    this.data.getValorantLeagues().subscribe((res: any) => {
+    this.data.getValorantLeagues(this.pages.valorantLeagues, this.pageSize).subscribe((res: any) => {
       this.valorantLeagues = res;
 
       console.log(this.valorantLeagues);
@@ -166,7 +242,7 @@ export class CategoriesComponent {
   }
 
   getValorantSeries() {
-    this.data.getValorantSeries().subscribe((res: any) => {
+    this.data.getValorantSeries(this.pages.valorantSeries, this.pageSize).subscribe((res: any) => {
       this.valorantSeries = res;
 
       console.log(this.valorantSeries);
@@ -174,7 +250,7 @@ export class CategoriesComponent {
   }
 
   getValorantTournaments() {
-    this.data.getValorantTournaments().subscribe((res: any) => {
+    this.data.getValorantTournaments(this.pages.valorantTournaments, this.pageSize).subscribe((res: any) => {
       this.valorantTournaments = res;
 
       console.log(this.valorantTournaments);
@@ -182,7 +258,7 @@ export class CategoriesComponent {
   }
 
   getValorantMatches() {
-    this.data.getValorantMatches().subscribe((res: any) => {
+    this.data.getValorantMatches(this.pages.valorantMatches, this.pageSize).subscribe((res: any) => {
       this.valorantMatches = res;
 
       console.log(this.valorantMatches);

--- a/src/app/sections/discover/discover.component.ts
+++ b/src/app/sections/discover/discover.component.ts
@@ -27,75 +27,139 @@ export class DiscoverComponent {
   vweapons : any[] = [];
   vagents : any[] = [];
 
+  pageSize = 10;
+  pages: { [key: string]: number } = {
+    maps: 1,
+    weapons: 1,
+    abilities: 1,
+    heroes: 1,
+    items: 1,
+    lolchamps: 1,
+    lolitems: 1,
+    lolrunes: 1,
+    lolspells: 1,
+    vabilities: 1,
+    vmaps: 1,
+    vweapons: 1,
+    vagents: 1
+  };
+
   constructor(private data: DataService) {
     this.getCSGOmaps();
     this.getCSGOweapons();
   }
+
+  changePage(key: string, delta: number) {
+    const next = (this.pages[key] || 1) + delta;
+    if (next < 1) return;
+    this.pages[key] = next;
+    switch (key) {
+      case 'maps':
+        this.getCSGOmaps();
+        break;
+      case 'weapons':
+        this.getCSGOweapons();
+        break;
+      case 'abilities':
+        this.getDota2Abilities();
+        break;
+      case 'heroes':
+        this.getDota2heroes();
+        break;
+      case 'items':
+        this.getDota2items();
+        break;
+      case 'lolchamps':
+        this.getLolChampions();
+        break;
+      case 'lolitems':
+        this.getLolItemns();
+        break;
+      case 'lolrunes':
+        this.getLolrunes();
+        break;
+      case 'lolspells':
+        this.getLolspells();
+        break;
+      case 'vabilities':
+        this.getValoranabilities();
+        break;
+      case 'vmaps':
+        this.getValorantmaps();
+        break;
+      case 'vweapons':
+        this.getValorantweapons();
+        break;
+      case 'vagents':
+        this.getValorantagents();
+        break;
+    }
+  }
   getCSGOmaps() {
-    this.data.getCSGOmaps().subscribe((res: any) => {
+    this.data.getCSGOmaps(this.pages.maps, this.pageSize).subscribe((res: any) => {
       this.maps = res;
       this.currentView = 'maps';
     });
   }
 
   getCSGOweapons() {
-    this.data.getCSGOweapons().subscribe((res: any) => {
+    this.data.getCSGOweapons(this.pages.weapons, this.pageSize).subscribe((res: any) => {
       this.weapons = res;
       this.currentView = 'weapons';
     });
   }
 
   getDota2Abilities(){
-    this.data.getDota2Abilities().subscribe((res: any) => {
+    this.data.getDota2Abilities(this.pages.abilities, this.pageSize).subscribe((res: any) => {
       this.dotaAbilities = res;
       this.currentView = 'abilities';
     });
   }
   getDota2heroes(){
-    this.data.getDota2heroes().subscribe((res: any) => {
+    this.data.getDota2heroes(this.pages.heroes, this.pageSize).subscribe((res: any) => {
       this.dotaheores = res;
       this.currentView = 'heroes';
     });
   }
   getDota2items(){
-    this.data.getDota2items().subscribe((res: any) => {
+    this.data.getDota2items(this.pages.items, this.pageSize).subscribe((res: any) => {
       this.dotaItems = res;
       this.currentView = 'items';
     });
   }
   getLolChampions(){
-    this.data.getLolChampions().subscribe((res: any) => {
+    this.data.getLolChampions(this.pages.lolchamps, this.pageSize).subscribe((res: any) => {
       this.lolchamps = res;
       this.currentView = 'lolchamps';
     });
   }
   getLolItemns(){
-    this.data.getLolItemns().subscribe((res: any) => {
+    this.data.getLolItemns(this.pages.lolitems, this.pageSize).subscribe((res: any) => {
       this.lolitems = res;
       this.currentView = 'lolitems';
     });
   }
   getLolrunes(){
-    this.data.getLolrunes().subscribe((res: any) => {
+    this.data.getLolrunes(this.pages.lolrunes, this.pageSize).subscribe((res: any) => {
       this.lolrunes = res;
       this.currentView = 'lolrunes';
     });
   }
   getLolspells(){
-    this.data.getLolspells().subscribe((res: any) => {
+    this.data.getLolspells(this.pages.lolspells, this.pageSize).subscribe((res: any) => {
       this.lolspells = res;
       this.currentView = 'lolspells';
     });
   }
   getValoranabilities(){
-    this.data.getValoranabilities().subscribe((res: any) => {
+    this.data.getValoranabilities(this.pages.vabilities, this.pageSize).subscribe((res: any) => {
       this.vabilities = res;
       this.currentView = 'vabilities';
     });
 
   }
    getValorantmaps(){
-    this.data.getValorantmaps().subscribe((res: any) => {
+    this.data.getValorantmaps(this.pages.vmaps, this.pageSize).subscribe((res: any) => {
       this.vmaps = res;
       this.currentView = 'vmaps';
     });
@@ -103,14 +167,14 @@ export class DiscoverComponent {
   }
 
    getValorantweapons(){
-    this.data.getValorantweapons().subscribe((res: any) => {
+    this.data.getValorantweapons(this.pages.vweapons, this.pageSize).subscribe((res: any) => {
       this.vweapons = res;
       this.currentView = 'vweapons';
     });
 
   }
    getValorantagents(){
-    this.data.getValorantagents().subscribe((res: any) => {
+    this.data.getValorantagents(this.pages.vagents, this.pageSize).subscribe((res: any) => {
       this.vagents = res;
       this.currentView = 'vagents';
     });

--- a/src/app/sections/home/home.component.html
+++ b/src/app/sections/home/home.component.html
@@ -112,7 +112,7 @@
               <!-- PLAYERS -->
               @if (currentView === 'players') {
               <div class="row g-4">
-                @for (p of players.slice(0,12); track $index) {
+                @for (p of players; track $index) {
                 <div class="col-12 col-md-6">
                   <div class="recommended-card bg-dark border border-secondary p-4 rounded text-light shadow-sm h-100">
                     <h5 class="mb-2 text-warning">
@@ -137,6 +137,10 @@
                   </div>
                 </div>
                 }
+              </div>
+              <div class="d-flex justify-content-between mt-3">
+                <button class="btn btn-secondary btn-sm" (click)="changePage('players', -1)" [disabled]="playersPage === 1">Anterior</button>
+                <button class="btn btn-secondary btn-sm" (click)="changePage('players', 1)">Siguiente</button>
               </div>
               }
 
@@ -168,6 +172,10 @@
                   </div>
                 </div>
                 }
+              </div>
+              <div class="d-flex justify-content-between mt-3">
+                <button class="btn btn-secondary btn-sm" (click)="changePage('teams', -1)" [disabled]="teamsPage === 1">Anterior</button>
+                <button class="btn btn-secondary btn-sm" (click)="changePage('teams', 1)">Siguiente</button>
               </div>
               }
 
@@ -215,6 +223,10 @@
               </div>
               }
               }
+              <div class="d-flex justify-content-between mt-3">
+                <button class="btn btn-secondary btn-sm" (click)="changePage('matches', -1)" [disabled]="matchesPage === 1">Anterior</button>
+                <button class="btn btn-secondary btn-sm" (click)="changePage('matches', 1)">Siguiente</button>
+              </div>
               }
             </div>
           </div>

--- a/src/app/sections/home/home.component.ts
+++ b/src/app/sections/home/home.component.ts
@@ -27,6 +27,12 @@ export class HomeComponent implements OnInit {
   successMsg: string = '';
   errorMsg: string = '';
 
+  pageSize = 10;
+  leaguesPage = 1;
+  teamsPage = 1;
+  playersPage = 1;
+  matchesPage = 1;
+
   // Lista local de favoritos guardados: {itemType, itemId}
   favorites: FavoriteResponse[] = [];
 
@@ -73,28 +79,28 @@ export class HomeComponent implements OnInit {
 
   // === Lógica de datos ===
   getDpts() {
-    this.data.getLeagues().subscribe((res: any) => {
+    this.data.getLeagues(this.leaguesPage, this.pageSize).subscribe((res: any) => {
       this.games = res;
       this.filteredGames = this.games;
     });
   }
 
   getTeams() {
-    this.data.getTeams().subscribe((res: any) => {
+    this.data.getTeams(this.teamsPage, this.pageSize).subscribe((res: any) => {
       this.teams = res;
       this.currentView = 'teams';
     });
   }
 
   getPlayers() {
-    this.data.getPlayers().subscribe((res: any) => {
+    this.data.getPlayers(this.playersPage, this.pageSize).subscribe((res: any) => {
       this.players = res;
       this.currentView = 'players';
     });
   }
 
   getMatches() {
-    this.data.getmatches().subscribe((res: any) => {
+    this.data.getmatches(this.matchesPage, this.pageSize).subscribe((res: any) => {
       this.matches = res;
       this.currentView = 'matches';
     });
@@ -116,6 +122,31 @@ export class HomeComponent implements OnInit {
 
   FiltrarOtros() {
     this.filteredGames = this.games.filter((g) => g.class_name === 'Other');
+  }
+
+  changePage(type: 'leagues' | 'teams' | 'players' | 'matches', delta: number) {
+    switch (type) {
+      case 'leagues':
+        if (this.leaguesPage + delta < 1) return;
+        this.leaguesPage += delta;
+        this.getDpts();
+        break;
+      case 'teams':
+        if (this.teamsPage + delta < 1) return;
+        this.teamsPage += delta;
+        this.getTeams();
+        break;
+      case 'players':
+        if (this.playersPage + delta < 1) return;
+        this.playersPage += delta;
+        this.getPlayers();
+        break;
+      case 'matches':
+        if (this.matchesPage + delta < 1) return;
+        this.matchesPage += delta;
+        this.getMatches();
+        break;
+    }
   }
 
   // Añadir favorito sin toggle (por si lo necesitas)


### PR DESCRIPTION
## Summary
- implement reusable paginate helper in DataService
- add page state and navigation in Home, Categories and Discover components
- implement example navigation buttons in templates
- provide paginate pipe (unused for now)

## Testing
- `npm test --silent --unsafe-perm` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857eff51e6c83289134e359dad8935c