### PR TITLE
Fix strict template access errors

### DIFF
--- a/src/app/sections/categories/categories.component.ts
+++ b/src/app/sections/categories/categories.component.ts
@@ -2,6 +2,24 @@ import { Component } from '@angular/core';
 import { DataService } from './../../data.service';
 import { CommonModule } from '@angular/common';
 
+export type PageKey =
+  | 'lolLeagues'
+  | 'lolSeries'
+  | 'lolTournaments'
+  | 'lolMatches'
+  | 'CSGOLeagues'
+  | 'CSGOSeries'
+  | 'CSGOTournaments'
+  | 'CSGOMatches'
+  | 'dota2Leagues'
+  | 'dota2Series'
+  | 'dota2Tournaments'
+  | 'dota2Matches'
+  | 'valorantLeagues'
+  | 'valorantSeries'
+  | 'valorantTournaments'
+  | 'valorantMatches';
+
 @Component({
   selector: 'app-categories',
   imports: [CommonModule],
@@ -34,7 +52,8 @@ export class CategoriesComponent {
   currentViewValorant: string = '';
 
   pageSize = 10;
-  pages: { [key: string]: number } = {
+
+  pages: Record<PageKey, number> = {
     lolLeagues: 1,
     lolSeries: 1,
     lolTournaments: 1,
@@ -73,7 +92,7 @@ export class CategoriesComponent {
   valorantTournaments: any[] = [];
   valorantMatches: any[] = [];
 
-  changePage(key: string, delta: number) {
+  changePage(key: PageKey, delta: number) {
     const next = (this.pages[key] || 1) + delta;
     if (next < 1) return;
     this.pages[key] = next;

--- a/src/app/sections/discover/discover.component.ts
+++ b/src/app/sections/discover/discover.component.ts
@@ -2,6 +2,21 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DataService } from '../../data.service';
 
+export type PageKey =
+  | 'maps'
+  | 'weapons'
+  | 'abilities'
+  | 'heroes'
+  | 'items'
+  | 'lolchamps'
+  | 'lolitems'
+  | 'lolrunes'
+  | 'lolspells'
+  | 'vabilities'
+  | 'vmaps'
+  | 'vweapons'
+  | 'vagents';
+
 @Component({
   selector: 'app-discover',
   imports: [CommonModule],
@@ -28,7 +43,7 @@ export class DiscoverComponent {
   vagents : any[] = [];
 
   pageSize = 10;
-  pages: { [key: string]: number } = {
+  pages: Record<PageKey, number> = {
     maps: 1,
     weapons: 1,
     abilities: 1,
@@ -49,7 +64,7 @@ export class DiscoverComponent {
     this.getCSGOweapons();
   }
 
-  changePage(key: string, delta: number) {
+  changePage(key: PageKey, delta: number) {
     const next = (this.pages[key] || 1) + delta;
     if (next < 1) return;
     this.pages[key] = next;


### PR DESCRIPTION
## Summary
- define PageKey types for strict object access
- update `pages` objects to use typed keys

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f2e072988328b5231f6ee1368399